### PR TITLE
Added Thicc Saber v1.0.0 to the mod repo

### DIFF
--- a/mods.json
+++ b/mods.json
@@ -1,1 +1,16 @@
-{}
+{
+    "1.17.1": [
+        {
+            "name": "Thicc Saber",
+            "description": "A simple mod which allows you to control the dimensions of notes!",
+            "id": "ThiccSaber",
+            "version": "1.0.0",
+            "downloadLink": "https://github.com/BobbyShmurner/ThiccSaber/releases/download/${GITHUB_REF#refs/tags/}/Thicc_Saber-v2.0.3.qmod",
+            "cover": "https://github.com/BobbyShmurner/ThiccSaber/raw/refs/tags/v2.0.3/cover.png",
+            "author": {
+                "name": "Bobby Shmurner",
+                "icon": "https://avatars.githubusercontent.com/u/34596112?v=4"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Added Thicc Saber v1.0.0 to the mod repo for Beat Saber version 1.17.1.

You can check out the build action [Here](https://github.com/BobbyShmurner/ThiccSaber/actions/runs/1940811766)

**Notes:**
- There were no mods found for the version 1.17.1, so a new verion entry was created