### PR TITLE
Added Hot-Swappable Mods v5.0.6 to the mod repo

### DIFF
--- a/mods.json
+++ b/mods.json
@@ -11,6 +11,18 @@
                 "name": "Bobby Shmurner",
                 "icon": "https://avatars.githubusercontent.com/u/34596112?v=4"
             }
+        },
+        {
+            "name": "Hot-Swappable Mods",
+            "description": "Allows you to easily reload mods from in game",
+            "id": "HotSwappableMods",
+            "version": "5.0.6",
+            "downloadLink": "https://github.com/BobbyShmurner/HotSwappableMods/releases/download/v5.0.6/Hot-Swappable_Mods-v5.0.6.qmod",
+            "cover": "https://github.com/BobbyShmurner/HotSwappableMods/raw/refs/tags/v5.0.6/cover.png",
+            "author": {
+                "name": "Bobby Shmurner",
+                "icon": "https://avatars.githubusercontent.com/u/34596112?v=4"
+            }
         }
     ]
 }


### PR DESCRIPTION
Added Hot-Swappable Mods v5.0.6 to the mod repo for Beat Saber version 1.17.1.

You can check out the build action [Here](https://github.com/BobbyShmurner/HotSwappableMods/actions/runs/1940820776)