### PR TITLE
Added Hot-Swappable Mods v5.1.0 to the mod repo

### DIFF
--- a/mods.json
+++ b/mods.json
@@ -1,1 +1,16 @@
-{}
+{
+    "1.17.1": [
+        {
+            "name": "Hot-Swappable Mods",
+            "description": "Allows you to easily reload mods from in game",
+            "id": "HotSwappableMods",
+            "version": "5.1.0",
+            "downloadLink": "https://github.com/BobbyShmurner/HotSwappableMods/releases/download/v5.1.0/Hot-Swappable_Mods-v5.1.0.qmod",
+            "cover": "https://github.com/BobbyShmurner/HotSwappableMods/raw/refs/tags/v5.1.0/cover.png",
+            "author": {
+                "name": "Bobby Shmurner",
+                "icon": "https://avatars.githubusercontent.com/u/34596112?v=4"
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Added Hot-Swappable Mods v5.1.0 to the mod repo for Beat Saber version 1.17.1.

You can check out the build action [Here](https://github.com/BobbyShmurner/HotSwappableMods/actions/runs/1941007924)
You can check out the release [Here](https://github.com/BobbyShmurner/HotSwappableMods/releases/tag/v5.1.0)
You can download the QMod [Here](https://github.com/BobbyShmurner/HotSwappableMods/releases/download/v5.1.0/Hot-Swappable_Mods-v5.1.0.qmod)

**Notes:**
- I didn't originally have a fork of the mod repo, so the workflow created one for me
- There were no mods found for the version 1.17.1, so a new verion entry was created