### PR TITLE
Added Thicc Saber v1.0.0 to the mod repo

### DIFF
--- a/mods.json
+++ b/mods.json
@@ -17,7 +17,7 @@
             "description": "A simple mod which allows you to control the dimensions of notes!",
             "id": "ThiccSaber",
             "version": "1.0.0",
-            "downloadLink": "https://github.com/BobbyShmurner/ThiccSaber/releases/download/v2.1.1/Thicc_Saber-v2.1.1.qmod",
+            "downloadLink": "https://github.com/BobbyShmurner/ThiccSaber/releases/download/v2.1.2/Thicc_Saber-v2.1.2.qmod",
             "cover": "",
             "author": {
                 "name": "Bobby Shmurner",

--- a/mods.json
+++ b/mods.json
@@ -17,7 +17,7 @@
             "description": "A simple mod which allows you to control the dimensions of notes!",
             "id": "ThiccSaber",
             "version": "1.0.0",
-            "downloadLink": "https://github.com/BobbyShmurner/ThiccSaber/releases/download/v2.1.2/Thicc_Saber-v2.1.2.qmod",
+            "downloadLink": "https://github.com/BobbyShmurner/ThiccSaber/releases/download/v2.1.3/Thicc_Saber-v2.1.3.qmod",
             "cover": "",
             "author": {
                 "name": "Bobby Shmurner",

--- a/mods.json
+++ b/mods.json
@@ -11,6 +11,18 @@
                 "name": "Bobby Shmurner",
                 "icon": "https://avatars.githubusercontent.com/u/34596112?v=4"
             }
+        },
+        {
+            "name": "Thicc Saber",
+            "description": "A simple mod which allows you to control the dimensions of notes!",
+            "id": "ThiccSaber",
+            "version": "1.0.0",
+            "downloadLink": "https://github.com/BobbyShmurner/ThiccSaber/releases/download/v2.1.1/Thicc_Saber-v2.1.1.qmod",
+            "cover": "",
+            "author": {
+                "name": "Bobby Shmurner",
+                "icon": "https://avatars.githubusercontent.com/u/34596112?v=4"
+            }
         }
     ]
 }

--- a/mods.json
+++ b/mods.json
@@ -17,7 +17,7 @@
             "description": "A simple mod which allows you to control the dimensions of notes!",
             "id": "ThiccSaber",
             "version": "1.0.0",
-            "downloadLink": "https://github.com/BobbyShmurner/ThiccSaber/releases/download/v2.1.3/Thicc_Saber-v2.1.3.qmod",
+            "downloadLink": "https://github.com/BobbyShmurner/ThiccSaber/releases/download/v2.1.4/Thicc_Saber-v2.1.4.qmod",
             "cover": "",
             "author": {
                 "name": "Bobby Shmurner",


### PR DESCRIPTION
Added Thicc Saber v1.0.0 to the mod repo for Beat Saber version 1.17.1.

You can check out the build action [Here](https://github.com/BobbyShmurner/ThiccSaber/actions/runs/1947506331)
You can check out the release [Here](https://github.com/BobbyShmurner/ThiccSaber/releases/tag/v2.1.2)
You can download the QMod [Here](https://github.com/BobbyShmurner/ThiccSaber/releases/download/v2.1.2/Thicc_Saber-v2.1.2.qmod)

**Notes:**
- "cover" was not specified, and "cover.png" could not be found in the root of the repo, so no cover was set